### PR TITLE
fix: unknown network error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,7 @@ local-chain-start:
 	anvil -p 8547 & \
 	anvil -p 8548 & \
 	anvil -p 8549 & \
+	sleep 10; \
 	node local/script/startLocalChain.js
 	@echo "Local script executed successfully!"
 


### PR DESCRIPTION
Add delay to fix unknown network error to give Anvil instances sometime to fully initialized and ready to accept connections.